### PR TITLE
improve timestamp in comfyui.log

### DIFF
--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -257,7 +257,7 @@ try:
 
         def sync_write(self, message, file_only=False):
             with log_lock:
-                timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')[:-3]
+                timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
                 if self.last_char != '\n':
                     log_file.write(message)
                 else:


### PR DESCRIPTION
before:
```
[2024-10-16 14:41] some log message (minute based)
```
after:
```
[2024-10-16 14:41:59.730] some log message (ms based)
```

accurate timestamp is helpful for understanding better how long execution take

seems there was a small bug removing last 3 chars from timestamp without microsec which actually removed the seconds `:%S` 
[datetime docs ref](https://docs.python.org/3/library/datetime.html#datetime.datetime.strftime)

